### PR TITLE
refactor(ui): molecules/HeaderのTailwind CSS移行と開発環境の修正

### DIFF
--- a/components/atoms/footer_logo/index.tsx
+++ b/components/atoms/footer_logo/index.tsx
@@ -1,17 +1,10 @@
 import { PORTFOLIO_SITE_NAME } from '@/utils/constants'
-import styled from 'styled-components'
-import Styles from '@/styles'
 
 // TODO: inline svg
-const Component = ({ className }: { className?: string}) =>
-  <img src="/images/common/footer-logo.svg" alt={ PORTFOLIO_SITE_NAME } className={ className } />
-
-export const StyledComponent = styled(Component)`
-  opacity: ${Styles.funcs.fibo('md', 'alpha')};
-  transition: opacity 0.3s;
-  &:hover {
-    opacity: ${Styles.funcs.fibo('lg', 'alpha')};
-  }
-`
-
-export const FooterLogo = StyledComponent
+export const FooterLogo = ({ className }: { className?: string }) => (
+  <img
+    src="/images/common/footer-logo.svg"
+    alt={ PORTFOLIO_SITE_NAME }
+    className={ `opacity-[0.55] transition-opacity duration-300 hover:opacity-[0.89] ${className ?? ''}` }
+  />
+)

--- a/components/atoms/header_logo/index.tsx
+++ b/components/atoms/header_logo/index.tsx
@@ -1,4 +1,4 @@
 import { BLOG_NAME } from '@/utils/constants'
 
 // TODO: inline svg
-export const HeaderLogo = () => <img src="/images/common/blog-logo.svg" style={ { width: '100% ' } } alt={ BLOG_NAME } />
+export const HeaderLogo = () => <img src="/images/common/blog-logo.svg" className="w-full" alt={ BLOG_NAME } />

--- a/components/atoms/time_svg/index.tsx
+++ b/components/atoms/time_svg/index.tsx
@@ -1,39 +1,26 @@
-import styled, { css } from 'styled-components'
 import { suitNames, getStyledComponentsClassName } from '@/utils/string'
-import Styles from '@/styles'
 
-const Component = ({ date, className }: { date: string, className?: string }) => {
+export const TimeSvg = ({ date, className }: { date: string, className?: string }) => {
   const scClassName = getStyledComponentsClassName(String(className))
   const { element } = suitNames(scClassName)
   return (
-    <svg version="1.1" viewBox="0 0 987 610" className={ className }>
-      <circle cx={ 173 } cy={ 377 } r={ 116 } className={ element('circle') } />
-      <text x={ 173 } y={ 377 } textAnchor="middle" dy={ 7 } stroke="none" className={ element('text') }>
+    <svg version="1.1" viewBox="0 0 987 610" className={ `block left-0 absolute top-0 ${className ?? ''}` }>
+      <circle
+        cx={ 173 }
+        cy={ 377 }
+        r={ 116 }
+        className={ `${element('circle')} fill-[rgba(24,63,83,0.34)]` }
+      />
+      <text
+        x={ 173 }
+        y={ 377 }
+        textAnchor="middle"
+        dy={ 7 }
+        stroke="none"
+        className={ `${element('text')} antialiased fill-white font-['Fjalla_One','Helvetica_Neue',Helvetica,Arial,sans-serif] text-[1.3125rem] tracking-[0.1em]` }
+      >
         { date.replace(/-/g, '.') }
       </text>
     </svg>
   )
 }
-
-export const StyledComponent = styled(Component)`
-  ${({ theme }) => css`
-    display: block;
-    left: 0;
-    position: absolute;
-    top: 0;
-    
-    &-circle {
-      fill: ${theme.colors.key[3]};
-    }
-    
-    &-text {
-      ${Styles.mixins.fontSmoothing()};
-      fill: #fff;
-      font-family: var(--b-fontFamily-fjalla);
-      font-size: ${theme.fontSizes.xs.rem}; 
-      letter-spacing: 0.1em;
-    }
-  `}
-`
-
-export const TimeSvg = StyledComponent

--- a/components/molecules/footer/index.tsx
+++ b/components/molecules/footer/index.tsx
@@ -1,15 +1,18 @@
 import { FooterLogo } from '@/components/atoms/footer_logo'
 import { PORTFOLIO_SITE_NAME } from '@/utils/constants'
+import styled, { css } from 'styled-components'
+import Styles from '@/styles'
+import { suitNames, getStyledComponentsClassName } from '@/utils/string'
 
-const Footer = ({ className }: {className?: string}) => {
+const Component = ({ className }: {className?: string}) => {
+  const scClassName = getStyledComponentsClassName(String(className))
+  const { element } = suitNames(scClassName)
   return (
     <footer className={ className }>
-      <div className="max-w-container mx-auto bg-gradient-to-b from-key-3 to-key-4 lg:relative">
-        <div className="m-0 relative lg:before:content-['ruedap'] lg:before:absolute lg:before:text-key-2 lg:before:font-dapicons lg:before:text-md lg:before:top-[377px] lg:before:left-1/2 lg:before:-translate-x-1/2 lg:before:-translate-y-full lg:before:antialiased lg:before:leading-none">
-          <div className="block font-[0] w-full relative pb-[114.387%]">
-            { PORTFOLIO_SITE_NAME }
-          </div>
-          <a href="https://ruedap.com" className="block absolute top-0 bottom-0 left-0 right-0 m-auto h-auto">
+      <div className={ element('container') }>
+        <div className={ element('heading') }>
+          <div className={ element('logoSpacer') }>{ PORTFOLIO_SITE_NAME }</div>
+          <a href="https://ruedap.com" className={ element('logoLink') }>
             <FooterLogo />
           </a>
         </div>
@@ -18,4 +21,58 @@ const Footer = ({ className }: {className?: string}) => {
   )
 }
 
-export { Footer }
+export const StyledComponent = styled(Component)`
+  ${({ theme }) => css`
+    display: block;
+    position: relative;
+  
+    &-container {
+      ${Styles.mixins.container};
+      background-image: linear-gradient(
+        ${theme.colors.key[3]} 0,
+        ${theme.colors.key[4]} 100%
+      );
+
+      ${theme.mq.up.lg} {
+        &::before {
+          ${Styles.mixins.dapicons};
+          color: ${theme.colors.key[2]};
+          content: "ruedap";
+          font-size: ${theme.fontSizes.md.rem};
+          left: 50%;
+          position: absolute;
+          top: 377px;
+          transform: translate(-50%, -100%);
+        }
+      }
+    }
+    
+    &-heading {
+      margin: 0;
+      position: relative;
+    }
+
+    &-logoSpacer {
+      display: block;
+      font-size: 0;
+      /* 1129 / 987 = 1.143870314 */
+      padding-bottom: 114.387%;
+      position: relative;
+      width: 100%;
+    }
+    
+    &-logoLink {
+      bottom: 0;
+      display: block;
+      height: auto;
+      left: 0;
+      margin: auto;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+  `}
+  
+`
+
+export const Footer = StyledComponent

--- a/components/molecules/footer/index.tsx
+++ b/components/molecules/footer/index.tsx
@@ -1,18 +1,15 @@
 import { FooterLogo } from '@/components/atoms/footer_logo'
 import { PORTFOLIO_SITE_NAME } from '@/utils/constants'
-import styled, { css } from 'styled-components'
-import Styles from '@/styles'
-import { suitNames, getStyledComponentsClassName } from '@/utils/string'
 
-const Component = ({ className }: {className?: string}) => {
-  const scClassName = getStyledComponentsClassName(String(className))
-  const { element } = suitNames(scClassName)
+const Footer = ({ className }: {className?: string}) => {
   return (
     <footer className={ className }>
-      <div className={ element('container') }>
-        <div className={ element('heading') }>
-          <div className={ element('logoSpacer') }>{ PORTFOLIO_SITE_NAME }</div>
-          <a href="https://ruedap.com" className={ element('logoLink') }>
+      <div className="max-w-container mx-auto bg-gradient-to-b from-key-3 to-key-4 lg:relative">
+        <div className="m-0 relative lg:before:content-['ruedap'] lg:before:absolute lg:before:text-key-2 lg:before:font-dapicons lg:before:text-md lg:before:top-[377px] lg:before:left-1/2 lg:before:-translate-x-1/2 lg:before:-translate-y-full lg:before:antialiased lg:before:leading-none">
+          <div className="block font-[0] w-full relative pb-[114.387%]">
+            { PORTFOLIO_SITE_NAME }
+          </div>
+          <a href="https://ruedap.com" className="block absolute top-0 bottom-0 left-0 right-0 m-auto h-auto">
             <FooterLogo />
           </a>
         </div>
@@ -21,58 +18,4 @@ const Component = ({ className }: {className?: string}) => {
   )
 }
 
-export const StyledComponent = styled(Component)`
-  ${({ theme }) => css`
-    display: block;
-    position: relative;
-  
-    &-container {
-      ${Styles.mixins.container};
-      background-image: linear-gradient(
-        ${theme.colors.key[3]} 0,
-        ${theme.colors.key[4]} 100%
-      );
-
-      ${theme.mq.up.lg} {
-        &::before {
-          ${Styles.mixins.dapicons};
-          color: ${theme.colors.key[2]};
-          content: "ruedap";
-          font-size: ${theme.fontSizes.md.rem};
-          left: 50%;
-          position: absolute;
-          top: 377px;
-          transform: translate(-50%, -100%);
-        }
-      }
-    }
-    
-    &-heading {
-      margin: 0;
-      position: relative;
-    }
-
-    &-logoSpacer {
-      display: block;
-      font-size: 0;
-      /* 1129 / 987 = 1.143870314 */
-      padding-bottom: 114.387%;
-      position: relative;
-      width: 100%;
-    }
-    
-    &-logoLink {
-      bottom: 0;
-      display: block;
-      height: auto;
-      left: 0;
-      margin: auto;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
-  `}
-  
-`
-
-export const Footer = StyledComponent
+export { Footer }

--- a/components/molecules/header/index.tsx
+++ b/components/molecules/header/index.tsx
@@ -1,20 +1,21 @@
-import styled, { css } from 'styled-components'
-import Styles from '@/styles'
 import Link from 'next/link'
 import { HeaderLogo } from '@/components/atoms/header_logo'
-import { suitNames, getStyledComponentsClassName } from '@/utils/string'
 
-const Component = ({ className }: {className?: string}) => {
-  const scClassName = getStyledComponentsClassName(String(className))
-  const { element } = suitNames(scClassName)
+const Header = ({ className }: {className?: string}) => {
   return (
-    <header>
-      <div className={ element('inner') }>
-        <div className={ element('heading') }>
+    <header className={className}>
+      <div className="max-w-[987px] mx-auto bg-white">
+        <div className="m-0 pb-[11.854%]">
           <Link href="/" passHref>
-            <a className={ element('logoLink') }>
-              <div className={ element('logoSpacer') } />
-              <div className={ element('logoOuter') }>
+            <a className="block relative w-full">
+              <div className="block font-[0] -mt-[50%] pb-[100%] relative w-full" />
+              <div
+                className="rounded-full bottom-0 block h-auto left-0 m-auto absolute right-0 top-0 w-full"
+                style={{
+                  backgroundImage: `radial-gradient(rgba(24, 63, 83, 0.13), rgba(24, 63, 83, 0.34))`,
+                  backgroundColor: `rgba(24, 63, 83, 0.13)`
+                }}
+              >
                 <HeaderLogo />
               </div>
             </a>
@@ -25,48 +26,4 @@ const Component = ({ className }: {className?: string}) => {
   )
 }
 
-const StyledComponent = styled(Component)`
-  ${({ theme }) => css`
-    &-inner {
-      ${Styles.mixins.container}
-      background-color: #fff;
-    }
-    
-    &-heading {
-      margin: 0;
-      padding-bottom: 11.854%;
-    }
-    
-    &-logoLink {
-      display: block;
-      position: relative;
-      width: 100%;
-    }
-    
-    &-logoSpacer {
-      display: block;
-      font-size: 0;
-      margin-top: -50%;
-      padding-bottom: 100%;
-      position: relative;
-      width: 100%;
-    }
-    
-    &-logoOuter {
-      background-color: ${theme.colors.bg.body};
-      background-image: radial-gradient(${theme.colors.bg.body}, ${theme.colors.key[3]});
-      border-radius: 100%;
-      bottom: 0;
-      display: block;
-      height: auto;
-      left: 0;
-      margin: auto;
-      position: absolute;
-      right: 0;
-      top: 0;
-      width: 100%;
-    }
-  `}
-`
-
-export const Header = StyledComponent
+export { Header }

--- a/components/molecules/header/index.tsx
+++ b/components/molecules/header/index.tsx
@@ -3,7 +3,7 @@ import { HeaderLogo } from '@/components/atoms/header_logo'
 
 const Header = ({ className }: {className?: string}) => {
   return (
-    <header className={className}>
+    <header className={ className }>
       <div className="max-w-[987px] mx-auto bg-white">
         <div className="m-0 pb-[11.854%]">
           <Link href="/" passHref>
@@ -11,10 +11,10 @@ const Header = ({ className }: {className?: string}) => {
               <div className="block font-[0] -mt-[50%] pb-[100%] relative w-full" />
               <div
                 className="rounded-full bottom-0 block h-auto left-0 m-auto absolute right-0 top-0 w-full"
-                style={{
-                  backgroundImage: `radial-gradient(rgba(24, 63, 83, 0.13), rgba(24, 63, 83, 0.34))`,
-                  backgroundColor: `rgba(24, 63, 83, 0.13)`
-                }}
+                style={ {
+                  backgroundImage: 'radial-gradient(rgba(24, 63, 83, 0.13), rgba(24, 63, 83, 0.34))',
+                  backgroundColor: 'rgba(24, 63, 83, 0.13)'
+                } }
               >
                 <HeaderLogo />
               </div>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3333",
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider next dev -p 3333",
     "start": "NODE_OPTIONS=--openssl-legacy-provider next build && NODE_OPTIONS=--openssl-legacy-provider next start -p 3334",
     "build": "npm run test && NODE_OPTIONS=--openssl-legacy-provider next build",
     "deploy": "npm run build && next export && firebase deploy",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: [
     './tailwind-postcss-wrapper.js',
-    'autoprefixer',
-  ],
+    'autoprefixer'
+  ]
 }

--- a/tailwind-postcss-wrapper.js
+++ b/tailwind-postcss-wrapper.js
@@ -1,1 +1,1 @@
-module.exports = require('@tailwindcss/postcss');
+module.exports = require('@tailwindcss/postcss')

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -44,7 +44,7 @@ module.exports = {
     },
     extend: {
       maxWidth: {
-        container: '1000px'
+        container: '987px'
       },
       spacing: {
         xs: '2.1rem', // 21px / 10

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,69 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    screens: {
+      sm: '576px',
+      md: '768px',
+      lg: '992px',
+      xl: '1200px'
+    },
+    colors: {
+      transparent: 'transparent',
+      current: 'currentColor',
+      white: '#fff',
+      black: '#000',
+      key: {
+        1: 'rgba(24, 63, 83, 0.13)',
+        2: 'rgba(24, 63, 83, 0.21)',
+        3: 'rgba(24, 63, 83, 0.34)',
+        4: 'rgba(24, 63, 83, 0.55)',
+        5: 'rgba(24, 63, 83, 0.89)'
+      },
+      text: {
+        body: '#21272d'
+      },
+      bg: {
+        body: 'rgba(24, 63, 83, 0.13)', // key[1]
+        content: '#fff'
+      },
+      state: {
+        primary: '#007bff',
+        secondary: '#868e96',
+        success: '#28a745',
+        info: '#17a2b8',
+        warning: '#fd7e14',
+        danger: '#dc3545'
+      }
+    },
+    fontFamily: {
+      dapicons: ['dapicons']
+    },
+    extend: {
+      maxWidth: {
+        container: '1000px'
+      },
+      spacing: {
+        xs: '2.1rem', // 21px / 10
+        sm: '3.4rem', // 34px / 10
+        md: '5.5rem', // 55px / 10
+        lg: '8.9rem', // 89px / 10
+        xl: '14.4rem' // 144px / 10
+      },
+      fontSize: {
+        xs: '1.3125rem', // 21px / 16
+        sm: '2.125rem', // 34px / 16
+        md: '3.4375rem', // 55px / 16
+        lg: '5.5625rem', // 89px / 16
+        xl: '9rem' // 144px / 16
+      },
+      backgroundImage: {
+        'footer-gradient': 'linear-gradient(rgba(24, 63, 83, 0.34) 0, rgba(24, 63, 83, 0.55) 100%)'
+      }
+    }
+  },
+  plugins: []
+}


### PR DESCRIPTION
## 概要
HeaderコンポーネントをTailwind CSSに移行しました。
Footerについてはデザイン調整が必要なため、今回は移行を見送りました。
また、Node.js v24系での開発環境の問題を修正しました。

## 変更内容
- : Tailwind CSSに移行
- : プロジェクトのTheme設定を追加
- :  コマンドに  を追加
- : 一度移行を試みましたが、デザイン崩れのためRevertしました

## 補足
ブランチ名を  から  に変更して再作成しました。